### PR TITLE
Adds pipe switches

### DIFF
--- a/_std/types.dm
+++ b/_std/types.dm
@@ -217,9 +217,10 @@ var/list/list/by_cat = list()
 #define TR_CAT_RANCID_STUFF "rancid_stuff"
 #define TR_CAT_GHOST_OBSERVABLES "ghost_observables"
 #define TR_CAT_STATION_EMERGENCY_LIGHTS "emergency_lights"
+#define TR_CAT_STAMINA_MOBS "stamina_mobs"
 //morrigan
 #define TR_CAT_MORRIGAN_LIGHTS "morrigan_lights"
-#define TR_CAT_STAMINA_MOBS "stamina_mobs"
+#define TR_CAT_SWITCHED_PIPES "switched_pipes"
 // powernets? processing_items?
 // mobs? ai-mobs?
 

--- a/assets/maps/allocated/morrigan.dmm
+++ b/assets/maps/allocated/morrigan.dmm
@@ -5667,6 +5667,10 @@
 /area/morrigan/derelict)
 "fGR" = (
 /obj/disposalpipe/segment,
+/obj/lever/pipeswitch{
+	id = "pipe_one";
+	switch_type = /obj/disposalpipe/junction/left/west
+	},
 /turf/unsimulated/floor/plating/damaged1,
 /area/morrigan/station/security/brig)
 "fHm" = (
@@ -23951,7 +23955,9 @@
 /turf/unsimulated/floor/auto/grass/leafy,
 /area/morrigan/station/medical/main)
 "xNk" = (
-/obj/disposalpipe/junction/right/east,
+/obj/disposalpipe/junction/right/east{
+	id = "pipe_one"
+	},
 /turf/unsimulated/floor/black,
 /area/morrigan/station/security/brig)
 "xNr" = (

--- a/code/WorkInProgress/recycling/disposal.dm
+++ b/code/WorkInProgress/recycling/disposal.dm
@@ -195,6 +195,8 @@
 
 
 	var/image/pipeimg = null
+	///For manual switching
+	var/id = null
 
 	// new pipe, set the icon_state as on map
 	New()
@@ -203,6 +205,10 @@
 		pipeimg = image(src.icon, src.loc, src.icon_state, 3, dir)
 		pipeimg.layer = OBJ_LAYER
 		pipeimg.dir = dir
+
+		//So we don't have to shove every single disposal pipe in a by_type
+		if (src.id)
+			START_TRACKING_CAT(TR_CAT_SWITCHED_PIPES)
 
 		// done here instead of world setup in case you want to load a big map in before the round starts or something
 		if (src.z == Z_LEVEL_STATION && global.current_state <= GAME_STATE_PREGAME)

--- a/code/z_adventurezones/morrigan.dm
+++ b/code/z_adventurezones/morrigan.dm
@@ -2984,3 +2984,28 @@ TYPEINFO(/obj/item/gun/energy/lasershotgun)
 					active = 1
 					SPAWN(2 MINUTES) active = 0
 					playsound(AM, pick(list('sound/effects/sparks1.ogg','sound/effects/sparks2.ogg','sound/effects/sparks3.ogg','sound/effects/sparks4.ogg','sound/effects/sparks5.ogg','sound/effects/sparks6.ogg'), 75, 0))
+
+/obj/lever/pipeswitch
+	///The ID to match with the particular pipe
+	var/id = null
+	///The /obj/disposalpipe type to switch to, changes on switching
+	var/switch_type = null
+
+	on()
+		src.do_switch()
+	off()
+		src.do_switch()
+
+	proc/do_switch()
+		if (!src.id || !src.switch_type)
+			return
+
+		for (var/obj/disposalpipe/pipe in by_cat[TR_CAT_SWITCHED_PIPES])
+			if (pipe.id == src.id)
+				var/pipe_type = pipe.type
+				var/turf/T = get_turf(pipe)
+				qdel(pipe)
+				var/obj/disposalpipe/newpipe = new src.switch_type(T)
+				newpipe.id = src.id
+				OTHER_START_TRACKING_CAT(newpipe, TR_CAT_SWITCHED_PIPES)
+				src.switch_type = pipe_type //so we switch back next time


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Adds `/obj/lever/pipeswitch` for switching pipes.
To set up a switch pipe set the `id` var on the switch and the pipe to the same value and set the `switch_type` var on the switch to the type you want it to switch to when you pull the lever (so if your pipe is `/obj/disposalpipe/junction/right/east`, setting `switch_type` to `/obj/disposalpipe/junction/left/west` will make it reverse directions every time you pull the switch)
I've set up one pipe switch in the brig back room connected to this junction as an example:
![image](https://github.com/Vispectral/goonstation/assets/20713227/944f7d03-836d-45d9-94c3-d3f9c495f9d3)

Feel free to mess with the sprite etc.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Pipe puzzle :)
