### PR TITLE
Gunbot abilities

### DIFF
--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -1428,6 +1428,7 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 			return !HH.limb.is_on_cooldown() && can_act(src,TRUE) //if we have limb cooldowns, use that, otherwise use can_act()
 		return can_act(src,TRUE)
 
+	/// Used for critters that range attack only with abilities
 	proc/can_critter_range_ability()
 		return FALSE
 

--- a/code/mob/living/critter.dm
+++ b/code/mob/living/critter.dm
@@ -722,8 +722,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 		if ((HH.can_range_attack || HH.can_special_attack()))
 			if (GET_DIST(src, target) > 1)
 				hand_range_attack(target, params)
-				return
+				return TRUE
 		if (HH.can_attack)
+			. = TRUE
 			if (ismob(target))
 				if (a_intent != INTENT_HELP)
 					if (mob_flags & AT_GUNPOINT)
@@ -1426,6 +1427,9 @@ ADMIN_INTERACT_PROCS(/mob/living/critter, proc/modify_health, proc/admincmd_atta
 		if(HH?.limb)
 			return !HH.limb.is_on_cooldown() && can_act(src,TRUE) //if we have limb cooldowns, use that, otherwise use can_act()
 		return can_act(src,TRUE)
+
+	proc/can_critter_range_ability()
+		return FALSE
 
 	/// Used for generic critter mobAI - returns TRUE when the mob is able to scavenge. For handling cooldowns, or other scavenge blocking conditions.
 	proc/can_critter_scavenge()

--- a/code/mob/living/critter/ai/generic_aiholders.dm
+++ b/code/mob/living/critter/ai/generic_aiholders.dm
@@ -31,6 +31,16 @@ if there is otherwise unique behaviour which you add to another mob consider mov
 	transition_tasks += holder.get_instance(/datum/aiTask/timed/wander/critter/aggressive, list(src.holder, src))
 	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/attack, list(src.holder, src))
 
+///Can be melee but also has a ranged ability
+/datum/aiHolder/aggressive/ranged_ability
+	New()
+		. = ..()
+		default_task = get_instance(/datum/aiTask/prioritizer/critter/aggressive/ranged_ability, list(src))
+
+/datum/aiTask/prioritizer/critter/aggressive/ranged_ability/New()
+	..()
+	transition_tasks += holder.get_instance(/datum/aiTask/sequence/goalbased/critter/range_ability, list(src.holder, src))
+
 /// Agressive Wanderer scavenger
 /datum/aiHolder/aggressive/scavenger
 	New()

--- a/code/z_adventurezones/morrigan/robots.dm
+++ b/code/z_adventurezones/morrigan/robots.dm
@@ -45,7 +45,7 @@
 	health_brute = 20
 	health_burn = 10
 	health_burn_vuln = 0.7
-	ai_type = /datum/aiHolder/aggressive
+	ai_type = /datum/aiHolder/aggressive/ranged_ability
 
 	New()
 		..()
@@ -82,6 +82,16 @@
 
 	setup_equipment_slots()
 		return
+
+	critter_ability_attack(var/target)
+		var/datum/targetable/critter/hookshot/ability = src.abilityHolder.getAbility(/datum/targetable/critter/hookshot)
+		if (!ability.disabled && ability.cooldowncheck())
+			ability.handleCast(target)
+			return TRUE
+
+	can_critter_range_ability()
+		var/datum/targetable/critter/hookshot/ability = src.abilityHolder.getAbility(/datum/targetable/critter/hookshot)
+		return !ability.disabled && ability.cooldowncheck()
 
 /mob/living/critter/robotic/gunbot/morrigan/riotbot
 	name = "Syndicate Suppression Unit"
@@ -128,11 +138,10 @@
 		HH.can_range_attack = TRUE
 
 	critter_ability_attack(mob/target)
-		var/datum/targetable/werewolf/werewolf_defense = src.abilityHolder.getAbility(/datum/targetable/werewolf/werewolf_defense)
-		if (!werewolf_defense.disabled && werewolf_defense.cooldowncheck())
-			werewolf_defense.handleCast(target)
+		var/datum/targetable/critter/shieldproto/ability = src.abilityHolder.getAbility(/datum/targetable/critter/shieldproto)
+		if (!ability.disabled && ability.cooldowncheck())
+			ability.handleCast(target)
 			return TRUE
-
 
 	get_melee_protection(zone, damage_type)
 		return 4
@@ -182,6 +191,12 @@
 		HH.icon_state = "hand_martian"
 		HH.name = "Soldering Iron"
 		HH.limb_name = "soldering iron"
+
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/nano_repair/ability = src.abilityHolder.getAbility(/datum/targetable/critter/nano_repair)
+		if (!ability.disabled && ability.cooldowncheck())
+			ability.handleCast(target)
+			return TRUE
 
 	get_melee_protection(zone, damage_type)
 		return 4

--- a/code/z_adventurezones/morrigan/robots.dm
+++ b/code/z_adventurezones/morrigan/robots.dm
@@ -245,6 +245,11 @@
 		HH.name = "right arm"
 		HH.limb_name = "mauler claws"
 
+	critter_ability_attack(mob/target)
+		var/datum/targetable/critter/robofast/ability = src.abilityHolder.getAbility(/datum/targetable/critter/robofast)
+		if (!ability.disabled && ability.cooldowncheck())
+			ability.handleCast(target)
+			return TRUE
 
 	get_melee_protection(zone, damage_type)
 		return 4


### PR DESCRIPTION
<!-- The text between the arrows are comments - they won't be visible on your PR. -->
<!-- To label this PR, add the label(s) without the prefixes surrounded by brackets anywhere, for example: [LABEL] -->
<!-- PRs should at least have one area (A-) label and at least one category (C-) label -->

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
Makes the morrigan specific gunbots use their abilities. For most of them that was relatively simple, but I had to write some custom behaviour for the meleebot. It's not very smart but it does use the ability!

This doesn't apply to the `/strong/` variants of the bots because they use cursed parallel inheritance that needs fixing, but I or someone else can do that later.

## Why's this needed? <!-- Describe why you think this should be added to the game. -->
Gunbots should use their unique stuff (also makes the zone harder >:) )
